### PR TITLE
修复字典数据初始化失败bug.

### DIFF
--- a/source/server/dao/InitDB.go
+++ b/source/server/dao/InitDB.go
@@ -59,7 +59,7 @@ func initDist() {
 	if nil == data || len(data) == 0 {
 
 		fmt.Println("------ 开始字典数据初始化 ------")
-		sqlBytes, err := os.ReadFile(exePath + "/sql/dists.sql")
+		sqlBytes, err := os.ReadFile(exePath + "/resources/sql/dists.sql")
 		util.CheckErr(err)
 		dist := string(sqlBytes)
 		// 过滤注释内容

--- a/source/server/dao/InitDB.go
+++ b/source/server/dao/InitDB.go
@@ -6,9 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "modernc.org/sqlite"
 	"os"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 var db *sql.DB
@@ -59,7 +60,7 @@ func initDist() {
 	if nil == data || len(data) == 0 {
 
 		fmt.Println("------ 开始字典数据初始化 ------")
-		sqlBytes, err := os.ReadFile(exePath + "/resources/sql/dists.sql")
+		sqlBytes, err := os.ReadFile(exePath + prefix + "/sql/dists.sql")
 		util.CheckErr(err)
 		dist := string(sqlBytes)
 		// 过滤注释内容

--- a/source/server/main.go
+++ b/source/server/main.go
@@ -50,7 +50,7 @@ func main() {
 		adminApi.POST("/online/download", controller.Download)
 	}
 	fmt.Println("-------- 服务启动成功：http://localhost:13303 --------")
-	err := router.Run(":13303")
+	err := router.Run("0.0.0.0:13303")
 	util.CheckErr(err)
 }
 

--- a/source/server/resources/sql/dists.sql
+++ b/source/server/resources/sql/dists.sql
@@ -18,26 +18,26 @@ PRAGMA foreign_keys = false;
 -- ----------------------------
 -- Records of dists
 -- ----------------------------
-INSERT INTO "dists" VALUES (1, 'distType', 'distType', '字典类型', 1);
-INSERT INTO "dists" VALUES (2, 'distType', 'expenseType', '消费类型', 2);
-INSERT INTO "dists" VALUES (3, 'distType', 'paymentType', '支付方式', 3);
-INSERT INTO "dists" VALUES (4, 'expenseType', '饮食', '饮食', 1);
-INSERT INTO "dists" VALUES (5, 'expenseType', '娱乐', '娱乐', 2);
-INSERT INTO "dists" VALUES (6, 'expenseType', '生活', '生活', 3);
-INSERT INTO "dists" VALUES (7, 'expenseType', '鞋服', '鞋服', 4);
-INSERT INTO "dists" VALUES (8, 'expenseType', '医护', '医护', 5);
-INSERT INTO "dists" VALUES (9, 'expenseType', '学习', '学习', 6);
-INSERT INTO "dists" VALUES (10, 'expenseType', '社交', '社交', 7);
-INSERT INTO "dists" VALUES (11, 'expenseType', '通讯', '通讯', 8);
-INSERT INTO "dists" VALUES (12, 'expenseType', '交通', '交通', 9);
-INSERT INTO "dists" VALUES (13, 'expenseType', '住宿', '住宿', 10);
-INSERT INTO "dists" VALUES (14, 'expenseType', '其他', '其他', 11);
-INSERT INTO "dists" VALUES (15, 'paymentType', '支付宝', '支付宝', 1);
-INSERT INTO "dists" VALUES (16, 'paymentType', '微信', '微信', 2);
-INSERT INTO "dists" VALUES (17, 'paymentType', '京东白条', '京东白条', 3);
-INSERT INTO "dists" VALUES (18, 'paymentType', '刷卡', '刷卡', 4);
-INSERT INTO "dists" VALUES (19, 'paymentType', '现金', '现金', 5);
-INSERT INTO "dists" VALUES (20, 'paymentType', '其他', '其他', 6);
+INSERT INTO "dists" VALUES (1, 'distType', 'distType', '字典类型', 1, NULL);
+INSERT INTO "dists" VALUES (2, 'distType', 'expenseType', '消费类型', 2, NULL);
+INSERT INTO "dists" VALUES (3, 'distType', 'paymentType', '支付方式', 3, NULL);
+INSERT INTO "dists" VALUES (4, 'expenseType', '饮食', '饮食', 1, NULL);
+INSERT INTO "dists" VALUES (5, 'expenseType', '娱乐', '娱乐', 2, NULL);
+INSERT INTO "dists" VALUES (6, 'expenseType', '生活', '生活', 3, NULL);
+INSERT INTO "dists" VALUES (7, 'expenseType', '鞋服', '鞋服', 4, NULL);
+INSERT INTO "dists" VALUES (8, 'expenseType', '医护', '医护', 5, NULL);
+INSERT INTO "dists" VALUES (9, 'expenseType', '学习', '学习', 6, NULL);
+INSERT INTO "dists" VALUES (10, 'expenseType', '社交', '社交', 7, NULL);
+INSERT INTO "dists" VALUES (11, 'expenseType', '通讯', '通讯', 8, NULL);
+INSERT INTO "dists" VALUES (12, 'expenseType', '交通', '交通', 9, NULL);
+INSERT INTO "dists" VALUES (13, 'expenseType', '住宿', '住宿', 10, NULL);
+INSERT INTO "dists" VALUES (14, 'expenseType', '其他', '其他', 11, NULL);
+INSERT INTO "dists" VALUES (15, 'paymentType', '支付宝', '支付宝', 1, NULL);
+INSERT INTO "dists" VALUES (16, 'paymentType', '微信', '微信', 2, NULL);
+INSERT INTO "dists" VALUES (17, 'paymentType', '京东白条', '京东白条', 3, NULL);
+INSERT INTO "dists" VALUES (18, 'paymentType', '刷卡', '刷卡', 4, NULL);
+INSERT INTO "dists" VALUES (19, 'paymentType', '现金', '现金', 5, NULL);
+INSERT INTO "dists" VALUES (20, 'paymentType', '其他', '其他', 6, NULL);
 
 -- ----------------------------
 -- Auto increment value for dists


### PR DESCRIPTION
alterTableSchema增加了字典的book_key字段
但dists.sql内字典初始化缺少book_key字段内容，导致字典数据初始化错误

```

-------- 数据库连接成功 --------

------ 开始字典数据初始化 ------

------ Something Error:  SQL logic error: table dists has 6 columns but 5 values were supplied (1)

------ 完成字典数据初始化 ------

```

是要给对应的book赋予不同的字典？